### PR TITLE
ドキュメントの精査

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,37 +15,70 @@ UiPathをやっていると、今いるディレクトリ名を取得したり�
 
 ## Path Utils
 ### Combine アクティビティ
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/53dddd49-a08f-e13c-0703-71c24d42aa4b.png)
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/1a2d1f2a-1363-8c3b-8f04-88c1fad673d7.png)
 
 指定されたパスの配列を連結して、パスを生成します。いわゆる
 
 ```
 {"c:¥temp","hogehoge"} → c:¥temp¥hogehoge
+{"temp","hogehoge"} → temp\hogehoge
+{"te/mp","hoge\hoge"} → te\mp\hoge\hoge
 ```
 
-な処理です。ふつうに文字列連結をすると `c:¥temphogehoge`などになりますが .NETの `System.IO.Path.Combine`  を呼び出して処理しています。ついでに、いわゆるスラもディレクトリの区切りとして処理したかったので、`String.Replace("/", "\\")` も入れてます。
+のような処理です。ふつうに文字列連結をすると `c:¥temphogehoge`などになりますが .NETの `System.IO.Path.Combine`  を呼び出して処理しています。ついでに、スラッシュ(/)もディレクトリの区切りとして処理したかったので、`String.Replace("/", "\\")` も入れてます。
 
 
 ### Current Dir アクティビティ
-
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/1ce599fd-4d0c-8aed-57ad-f3f5b2a43e36.png)
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/69f66769-0dba-a6f2-82e1-1487bc2812ba.png)
 
 現在のディレクトリのフルパスを返すアクティビティです。ただただ `Directory.GetCurrentDirectory`をしているだけ。
 
 ### Path Utils アクティビティ
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/09863a71-fee7-1a84-2c29-24d947e5d206.png)
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/ce895d06-8232-335c-efbb-9fbea652b179.png)
 
 相対パス・絶対パスを指定して、以下を取得するアクティビティです。
 
 |項目名|内容|
 |-----------------|------------------|
-| DirectoryName   | 原則 Path.GetDirectoryName() とおなじものを返します※|
+| DirectoryPath   | 原則 Path.GetDirectoryName() とおなじものを返します※|
 | DirExists       |指定したディレクトリが存在すればTrue(ファイルだったら存在してもFalse)|
 | FileExists      |指定したファイルが存在すればTrue(ディレクトリだったら存在してもFalse)|
 | FullPath        |フルパスが返ります|
 
-※ 基本、`Path.GetDirectoryName()` とおなじものを返しますが、存在するディレクトリを指定したときは末尾に"¥"がなくても、そのディレクトリ名を返します。 `Path.GetDirectoryName()`は末尾が"¥"で終わってないと、その上のディレクトリ名を返してしまうようですが。
+※ 基本、`Path.GetDirectoryName()` とおなじものを返しますが、存在するディレクトリを指定したときは末尾に"¥"がなくても、そのディレクトリパスを返します。 `Path.GetDirectoryName()`は末尾が"¥"で終わってないと、その上のディレクトリパスを返してしまうようですが。
 
+例:
+
+```
+Path: c:/temp/existsDir/
+→
+FullPath: c:\temp\existsDir\
+DirectoryPath: c:\temp\existsDir
+
+
+Path: c:/temp/existsDir
+→
+FullPath: c:\temp\existsDir
+DirectoryPath: c:\temp\existsDir  ←.NETのメソッドは、c:\temp\ を返しますが、。
+
+
+Path: c:/temp/notExistsDir/
+→
+FullPath: c:\temp\notExistsDir\
+DirectoryPath: c:\temp\notExistsDir
+
+
+Path: c:/temp/notExistsDir
+→
+FullPath: c:\temp\notExistsDir
+DirectoryPath: c:\temp
+
+
+Path: c:/temp/existsOrNotExistsFile.txt
+→
+FullPath: c:\temp\existsOrNotExistsFile.txt
+DirectoryPath: c:\temp
+```
 
 ## String Utils
 

--- a/README.md
+++ b/README.md
@@ -14,36 +14,73 @@ It provides the following functions.
 
 ## Path Utils
 ### Combine Activity
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/53dddd49-a08f-e13c-0703-71c24d42aa4b.png)
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/1a2d1f2a-1363-8c3b-8f04-88c1fad673d7.png)
 
  Combines an array of strings into a path. That is as follows:
 
 ```
 {"c:\temp","hogehoge"} → c:\temp\hogehoge
+{"temp","hogehoge"} → temp\hogehoge
+{"te/mp","hoge\hoge"} → te\mp\hoge\hoge
 ```
 
-calls `System.IO.Path.Combine` method . And calls `String.Replace("/", "\\")`  method to use '/' .
+calls `System.IO.Path.Combine` method . And calls `String.Replace("/", "\\")`  method to use `'/'` .
 
 ### Current Dir Activity
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/69f66769-0dba-a6f2-82e1-1487bc2812ba.png)
 
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/1ce599fd-4d0c-8aed-57ad-f3f5b2a43e36.png)
 
 Gets the current working directory. only calls `Directory.GetCurrentDirectory` method.
 
 
 ### Path Utils Activity
-![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/09863a71-fee7-1a84-2c29-24d947e5d206.png)
+![image.png](https://qiita-image-store.s3.amazonaws.com/0/73777/ce895d06-8232-335c-efbb-9fbea652b179.png)
 
 Specify relative/absolute path and get the following:
 
 |Properties|Description|
 |-----------------|------------------|
-| DirectoryName   |Basically it returns the same as `Path.GetDirectoryName()` ※.|
+| DirectoryPath   |Basically it returns the same as `Path.GetDirectoryName()` ※.|
 | DirExists       |returns true if the specified Directory exists (returns false even if it exists if it is a File).|
 | FileExists      |returns true if the specified File exists (returns false even if it exists if it is a Directory).|
 | FullPath        |returns full Path.|
 
-※ Basically it returns the same as `Path.GetDirectoryName()`. If an existing directory is specified, even if there is no "\\" at the end, the directory name is returned.
+※ Basically it returns the same as `Path.GetDirectoryName()`. If an existing directory is specified, even if there is no "\\" at the end, the directory path is returned.
+
+
+For examples:
+
+```
+Path: c:/temp/existsDir/
+→
+FullPath: c:\temp\existsDir\
+DirectoryPath: c:\temp\existsDir
+
+
+Path: c:/temp/existsDir
+→
+FullPath: c:\temp\existsDir
+DirectoryPath: c:\temp\existsDir   ← The .NET method returns c:\temp
+
+
+Path: c:/temp/notExistsDir/
+→
+FullPath: c:\temp\notExistsDir\
+DirectoryPath: c:\temp\notExistsDir
+
+
+Path: c:/temp/notExistsDir
+→
+FullPath: c:\temp\notExistsDir
+DirectoryPath: c:\temp
+
+
+Path: c:/temp/existsOrNotExistsFile.txt
+→
+FullPath: c:\temp\existsOrNotExistsFile.txt
+DirectoryPath: c:\temp
+```
+
 
 
 ## String Utils

--- a/UiPathGo.txt
+++ b/UiPathGo.txt
@@ -1,0 +1,48 @@
+■ Component Name
+String & Path Utilities
+
+■ Summary
+String & Path Utilities
+
+■Description
+This library is a custom activity for UiPath.
+
+When using UiPath, I often want to call methods of .NET, such as getting the name of the current directory, base64 encode the file,These activities are the activities that call those methods. It provides the following functions.
+
+See also: https://github.com/masatomix/UiPath_Path/blob/master/README.md
+
+
+
+■The benefits of this component
+
+Call the .NET method.
+
+ Combine: Combines an array of strings into a path.
+ Current Dir: Gets the current working directory.
+ Path Utils: Returns the absolute path for the specified path string ,checks the existence of the file ,etc.
+ Base64 Encode: Base64 Encode.
+ Base64 Decode: Base64 Decode.
+ Base64 Encode From File: Base64 Encode from File
+ ConvertCRLF: Convert the line feed code of the given text.
+ ToJSONString: An activity that converts arbitrary objects to JSON strings.
+See also: https://github.com/masatomix/UiPath_Path/blob/master/README.md
+
+
+■ Dependencies
+Newtonsoft.Json (>= 8.0.3)
+
+■ The compatibility of this component
+Built and tested with:
+
+UiPath Studio 2018.2
+UiPath Studio 2018.3
+
+
+■ Version release notes
+Change target framework to .NET Framework 4.5.
+Add dependency of Newtonsoft.Json.
+Add ToJson Activity.
+Add English readme.
+
+■ Last Updated
+20/08/2018

--- a/Utils/Common/DesignerMetadata.cs
+++ b/Utils/Common/DesignerMetadata.cs
@@ -34,10 +34,9 @@ namespace Utils
             // 1.Activitiesペイン上のツリー構造を構築する。
             // ドットで階層を表現する
             {
-                string PathUtils_categories = "Utils.Path Utilities";
-                builder.AddCustomAttributes(typeof(Combine), new CategoryAttribute(PathUtils_categories));
-                builder.AddCustomAttributes(typeof(CurrentDir), new CategoryAttribute(PathUtils_categories));
-                builder.AddCustomAttributes(typeof(Utils.PathUtils.PathUtils), new CategoryAttribute(PathUtils_categories));
+                builder.AddCustomAttributes(typeof(Combine), new CategoryAttribute(Resources.Category1_PathUtils));
+                builder.AddCustomAttributes(typeof(CurrentDir), new CategoryAttribute(Resources.Category1_PathUtils));
+                builder.AddCustomAttributes(typeof(Utils.PathUtils.PathUtils), new CategoryAttribute(Resources.Category1_PathUtils));
             }
 
             // 2.Activitiesペイン上のアクティビティ名
@@ -75,7 +74,9 @@ namespace Utils
             //}
 
             // 6.プロパティペイン内のプロパティの変数名
-            //builder.AddCustomAttributes(typeof(Combine), nameof(Combine.PathArray), new DisplayNameAttribute("test display1"));  //クラスのプロパティに直接 DisplayNameを書いたのと意味おなじ。
+            {
+                builder.AddCustomAttributes(typeof(Utils.PathUtils.PathUtils), nameof(Utils.PathUtils.PathUtils.DirectoryName), new DisplayNameAttribute(Resources.DisplayName6_PathUtils_DirectoryName));
+            }
         }
 
         private void addCustomAttributes_StringUtils_categoriess(AttributeTableBuilder builder)
@@ -84,12 +85,11 @@ namespace Utils
             // 1.Activitiesペイン上のツリー構造を構築する。
             // ドットで階層を表現する
             {
-                string StringUtils_categories = "Utils.String Utilities";
-                builder.AddCustomAttributes(typeof(Base64Encode), new CategoryAttribute(StringUtils_categories));
-                builder.AddCustomAttributes(typeof(Base64Decode), new CategoryAttribute(StringUtils_categories));
-                builder.AddCustomAttributes(typeof(Base64EncodeFromFile), new CategoryAttribute(StringUtils_categories));
-                builder.AddCustomAttributes(typeof(ConvertCRLF), new CategoryAttribute(StringUtils_categories));
-                builder.AddCustomAttributes(typeof(ToJSONString), new CategoryAttribute(StringUtils_categories));
+                builder.AddCustomAttributes(typeof(Base64Encode), new CategoryAttribute(Resources.Category1_StringUtils));
+                builder.AddCustomAttributes(typeof(Base64Decode), new CategoryAttribute(Resources.Category1_StringUtils));
+                builder.AddCustomAttributes(typeof(Base64EncodeFromFile), new CategoryAttribute(Resources.Category1_StringUtils));
+                builder.AddCustomAttributes(typeof(ConvertCRLF), new CategoryAttribute(Resources.Category1_StringUtils));
+                builder.AddCustomAttributes(typeof(ToJSONString), new CategoryAttribute(Resources.Category1_StringUtils));
             }
 
             // 2.Activitiesペイン上のアクティビティ名

--- a/Utils/PathUtils/Combine.cs
+++ b/Utils/PathUtils/Combine.cs
@@ -27,9 +27,9 @@ namespace Utils.PathUtils
         protected override void Execute(CodeActivityContext context)
         {
             var paths = PathArray.Get(context);
-            var combine = System.IO.Path.GetFullPath(
-                System.IO.Path.Combine(paths)
-                .Replace("/", "\\"));
+            var combine = System.IO.Path
+                .Combine(paths)
+                .Replace("/", "\\");
             // ユーザが "/" にしたときもバックスラッシュで返す
             Result.Set(context, combine);
         }

--- a/Utils/PathUtils/PathUtils.cs
+++ b/Utils/PathUtils/PathUtils.cs
@@ -24,7 +24,7 @@ namespace Utils.PathUtils
 
 
         [Category("Output")]
-        public OutArgument<String> DirectoryName { get; set; }
+        public OutArgument<String> DirectoryName { get; set; } // DesignerMetadata.csで、表記(DisplayName)をoverride
 
 
         [Category("Output")]
@@ -61,8 +61,11 @@ namespace Utils.PathUtils
                 // fullPathStrの元になっている pathStrの末尾が\で終わる場合、終わらない場合があり
                 // \で終了していない場合、GetDirectoryName はその上のパスを返してしまう
                 // そのディレクトリが存在するときくらい、そのパス自体を返してあげるべきでは、という対応
-                var tmp = System.IO.Path.Combine(fullPathStr, "dummy.txt");
 
+                // Basically it returns the same as `Path.GetDirectoryName()`. 
+                // If an existing directory is specified, even if there is no "\" at the end, 
+                // the directory path is returned.
+                var tmp = System.IO.Path.Combine(fullPathStr, "dummy.txt");
                 //  DirectoryName セクション
                 context.SetValue(DirectoryName, System.IO.Path.GetDirectoryName(tmp));
             }

--- a/Utils/Properties/AssemblyInfo.cs
+++ b/Utils/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 以下のように '*' を使用します:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.77.0")]
+[assembly: AssemblyVersion("0.1.86.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Utils/Properties/Resources.Designer.cs
+++ b/Utils/Properties/Resources.Designer.cs
@@ -223,7 +223,7 @@ namespace Utils.Properties {
         }
         
         /// <summary>
-        ///   Returns the same as Path.GetDirectoryName().If an existing directory is specified, even if there is no &quot;\&quot; at the end, the directory name is returned. に類似しているローカライズされた文字列を検索します。
+        ///   Returns the same as Path.GetDirectoryName().If an existing directory is specified, even if there is no &quot;\&quot; at the end, the directory path is returned. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Description4_PathUtils_DirectoryName {
             get {
@@ -336,6 +336,15 @@ namespace Utils.Properties {
         public static string DisplayName2_ToJSONString {
             get {
                 return ResourceManager.GetString("DisplayName2_ToJSONString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   DirectoryPath に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string DisplayName6_PathUtils_DirectoryName {
+            get {
+                return ResourceManager.GetString("DisplayName6_PathUtils_DirectoryName", resourceCulture);
             }
         }
     }

--- a/Utils/Properties/Resources.ja-JP.resx
+++ b/Utils/Properties/Resources.ja-JP.resx
@@ -120,8 +120,8 @@
   <data name="Description4_Combine_PathArray" xml:space="preserve">
     <value>stringの配列で、連結したいファイルパスを記述します。</value>
   </data>
-  <data name="Description4_PathUtils_DirectoryName_Desc" xml:space="preserve">
-    <value>Directory名が返ります。原則 Path.GetDirectoryName() とおなじものを返しますが存在するディレクトリを指定したときは末尾に\\がなくてもそのディレクトリ名を返します。Path.GetDirectoryName()はその上のディレクトリ名を返してしまうようで。。</value>
+  <data name="Description4_PathUtils_DirectoryName" xml:space="preserve">
+    <value>Directoryのフルパスが返ります。原則 Path.GetDirectoryName() とおなじものを返しますが存在するディレクトリを指定したときは末尾に\がなくても、そのディレクトリパスを返します。Path.GetDirectoryName()はその上のディレクトリパスを返してしまうようで。。</value>
   </data>
   <data name="Description4_PathUtils_DirExists" xml:space="preserve">
     <value>指定したディレクトリが存在すればTrue(ファイルだったら存在してもFalse)</value>

--- a/Utils/Properties/Resources.ja.resx
+++ b/Utils/Properties/Resources.ja.resx
@@ -120,8 +120,8 @@
   <data name="Description4_Combine_PathArray" xml:space="preserve">
     <value>stringの配列で、連結したいファイルパスを記述します。</value>
   </data>
-  <data name="Description4_PathUtils_DirectoryName_Desc" xml:space="preserve">
-    <value>Directory名が返ります。原則 Path.GetDirectoryName() とおなじものを返しますが存在するディレクトリを指定したときは末尾に\\がなくてもそのディレクトリ名を返します。Path.GetDirectoryName()はその上のディレクトリ名を返してしまうようで。。</value>
+  <data name="Description4_PathUtils_DirectoryName" xml:space="preserve">
+    <value>Directoryのフルパスが返ります。原則 Path.GetDirectoryName() とおなじものを返しますが存在するディレクトリを指定したときは末尾に\がなくても、そのディレクトリパスを返します。Path.GetDirectoryName()はその上のディレクトリパスを返してしまうようで。。</value>
   </data>
   <data name="Description4_PathUtils_DirExists" xml:space="preserve">
     <value>指定したディレクトリが存在すればTrue(ファイルだったら存在してもFalse)</value>

--- a/Utils/Properties/Resources.resx
+++ b/Utils/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description4_PathUtils_DirectoryName" xml:space="preserve">
-    <value>Returns the same as Path.GetDirectoryName().If an existing directory is specified, even if there is no "\" at the end, the directory name is returned.</value>
+    <value>Returns the same as Path.GetDirectoryName().If an existing directory is specified, even if there is no "\" at the end, the directory path is returned.</value>
   </data>
   <data name="Description4_PathUtils_DirExists" xml:space="preserve">
     <value>Returns true if the specified Directory exists (returns false even if it exists if it is a File).</value>
@@ -209,5 +209,8 @@
   </data>
   <data name="DisplayName2_ToJSONString" xml:space="preserve">
     <value>To JSON String</value>
+  </data>
+  <data name="DisplayName6_PathUtils_DirectoryName" xml:space="preserve">
+    <value>DirectoryPath</value>
   </data>
 </root>

--- a/Utils/Utils.csproj
+++ b/Utils/Utils.csproj
@@ -24,7 +24,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Utils/Utils.nuspec
+++ b/Utils/Utils.nuspec
@@ -12,17 +12,21 @@
     <description>
 When using UiPath, I often want to call methods of .NET, such as getting the name of the current directory, base64 encode the file,These activities are the activities that call those methods.
 
+See also: https://github.com/masatomix/UiPath_Path/blob/master/README.md
 
 UiPathをやっていると、今いるディレクトリ名を取得したり、ファイルをBase64 Encodeしたりなど、.NETのメソッドを呼びたいことがちょくちょくあるのですが、それらを呼び出すアクティビティになっています。
 
 </description>
     <releaseNotes>
-Available in English.
-Externalize Strings.
+Localization using Language of UiPath.
+Combine activity - When the path array is a relative path,I added the current directory, but I changed it so that I do not add it.
+Path Utils activity - Property name "DirectoryName" changed to "DirectoryPath".
 
-英語ロケールでは、英語表記になるように対応
+UiPathの言語設定によって、日本語表記・英語表記になるように対応
 というかデフォルトを英語とし、日本語ロケールで日本語表記になるように対応。Studio 2018.2までは日本語ロケールで起動しないので、英語表記となります。単純だから問題ないと思いますが。。
-文字列の外部化と、日本語リソースの作成が完了。
+
+Combine activity - パス配列に相対パスを指定したとき、カレントディレクトリを付与していたのですが、付与しないように変更しました。
+Path Utils activity - プロパティ名が"DirectoryName"だったのを、実際はパスを返しているため"DirectoryPath"に変更しました。
 </releaseNotes>
     <copyright>Copyright 2018 masatomix</copyright>
   </metadata>


### PR DESCRIPTION
Combine activity - パス配列に相対パスを指定したとき、カレントディレクトリを付与していたのですが、付与しないように変更しました。
Path Utils activity - プロパティ名が"DirectoryName"だったのを、実際はパスを返しているため"DirectoryPath"に変更しました。